### PR TITLE
Update coupon selector.

### DIFF
--- a/src/components/wp-admin/component-meta-box-coupon-data.js
+++ b/src/components/wp-admin/component-meta-box-coupon-data.js
@@ -50,6 +50,6 @@ export default class ComponentMetaBoxCouponData extends ComponentMetaBox {
 
 	_getTabSelector( tab, args = { active: false } ) {
 		const li = args.active ? 'li[contains(@class, "active")]' : 'li';
-		return By.xpath( `//ul[contains(@class,"coupon_data_tabs")]//${ li }/a[contains(text(), "${ tab }")]` );
+		return By.xpath( `//ul[contains(@class,"coupon_data_tabs")]//${ li }/a[contains(., "${ tab }")]` );
 	}
 }


### PR DESCRIPTION
The tab text is now wrapped in a span, so the selector had to be updated to match on the tab correctly