### PR TITLE
Wait till animations are finished before toggling

### DIFF
--- a/src/components/wp-admin/component-product-data-variation-row.js
+++ b/src/components/wp-admin/component-product-data-variation-row.js
@@ -4,6 +4,7 @@
 import { By } from 'selenium-webdriver';
 import { WebDriverHelper as helper } from 'wp-e2e-webdriver';
 import { Component } from 'wp-e2e-page-objects';
+import * as wcHelper from '../../helper';
 
 export default class ComponentProductDataVariationRow extends Component {
 	constructor( driver, selector ) {
@@ -116,6 +117,8 @@ export default class ComponentProductDataVariationRow extends Component {
 	}
 
 	toggle() {
+		wcHelper.waitTillAnimationFinished( this.driver );
+
 		this.driver.actions().
 			mouseMove( this.driver.findElement( By.css( this.selector.value + ' > h3 > .handlediv' ) ) ).
 			click().

--- a/src/helper.js
+++ b/src/helper.js
@@ -5,6 +5,7 @@ import { By } from 'selenium-webdriver';
 import { WebDriverHelper as helper } from 'wp-e2e-webdriver';
 
 const UI_BLOCK_SELECTOR = By.css( '.blockUI.blockOverlay' );
+const ANIMATION_SELECTOR = By.css( ':animated' );
 
 export function waitTillUIBlockPresent( driver, waitMs = 10000 ) {
 	return helper.waitTillPresentAndDisplayed( driver, UI_BLOCK_SELECTOR, waitMs );
@@ -12,6 +13,10 @@ export function waitTillUIBlockPresent( driver, waitMs = 10000 ) {
 
 export function waitTillUIBlockNotPresent( driver, waitMs = 10000 ) {
 	return helper.waitTillNotPresent( driver, UI_BLOCK_SELECTOR, waitMs );
+}
+
+export function waitTillAnimationFinished( driver, waitMs = 10000 ) {
+	return helper.waitTillNotPresent( driver, ANIMATION_SELECTOR, waitMs );
 }
 
 export function waitTillAlertAccepted( driver, waitMs = 10000 ) {


### PR DESCRIPTION
This fixes #9.

I am 90% sure the problem is caused by this:
```
const var1 = panelVaritions.getRow( 1 );
var1.toggle();
...
const var2 = panelVaritions.getRow( 2 );
var2.toggle();
...
const var3 = panelVaritions.getRow( 3 );
var3.toggle();
```

My theory is that `toggle()` is getting called while the previous row is still animating from `toggle`, so it moves the mouse and clicks on a position that isn't the correct position any more.  I've changed `toggle` to wait until all jQuery animations are finished before moving the mouse and clicking. I tested it 20+ times in a row with no failures.

@gedex can you please take a look at my solution and also verify the problem is fixed when you run the tests? Thanks!