### PR TITLE
Scroll to row before trying to check checkboxes

### DIFF
--- a/src/components/wp-admin/component-product-data-variation-row.js
+++ b/src/components/wp-admin/component-product-data-variation-row.js
@@ -13,41 +13,49 @@ export default class ComponentProductDataVariationRow extends Component {
 
 	checkEnabled() {
 		const selector = By.css( this.selector.value + ' input[name^="variable_enabled"]' );
+		helper.mouseMoveTo( this.driver, this.selector );
 		return helper.setCheckbox( this.driver, selector );
 	}
 
 	uncheckEnabled() {
 		const selector = By.css( this.selector.value + ' input[name^="variable_enabled"]' );
+		helper.mouseMoveTo( this.driver, this.selector );
 		return helper.unsetCheckbox( this.driver, selector );
 	}
 
 	checkVirtual() {
 		const selector = By.css( this.selector.value + ' input[name^="variable_is_virtual"]' );
+		helper.mouseMoveTo( this.driver, this.selector );
 		return helper.setCheckbox( this.driver, selector );
 	}
 
 	uncheckVirtual() {
 		const selector = By.css( this.selector.value + ' input[name^="variable_is_virtual"]' );
+		helper.mouseMoveTo( this.driver, this.selector );
 		return helper.unsetCheckbox( this.driver, selector );
 	}
 
 	checkDownloadable() {
 		const selector = By.css( this.selector.value + ' input[name^="variable_is_downloadable"]' );
+		helper.mouseMoveTo( this.driver, this.selector );
 		return helper.setCheckbox( this.driver, selector );
 	}
 
 	uncheckDownloadable() {
 		const selector = By.css( this.selector.value + ' input[name^="variable_is_downloadable"]' );
+		helper.mouseMoveTo( this.driver, this.selector );
 		return helper.unsetCheckbox( this.driver, selector );
 	}
 
 	checkManageStock() {
 		const selector = By.css( this.selector.value + ' input[name^="variable_manage_stock"]' );
+		helper.mouseMoveTo( this.driver, this.selector );
 		return helper.setCheckbox( this.driver, selector );
 	}
 
 	uncheckManageStock() {
 		const selector = By.css( this.selector.value + ' input[name^="variable_manage_stock"]' );
+		helper.mouseMoveTo( this.driver, this.selector );
 		return helper.unsetCheckbox( this.driver, selector );
 	}
 


### PR DESCRIPTION
Fixes #9.

Good call on the mouseMoveTo @gedex. This should fix the sometimes-failing variations test, and any future tests that need to check any of the variation checkboxes. The driver will now move to the variations row before trying to check a box in it.