### PR TITLE
Admin tax settings objects + tests

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,7 @@ import WPAdminProductNew from './pages/wp-admin/wp-admin-product-new';
 import WPAdminWCSettings from './pages/wp-admin/wp-admin-wc-settings';
 import WPAdminWCSettingsGeneral from './pages/wp-admin/wp-admin-wc-settings-general';
 import WPAdminWCSettingsTax from './pages/wp-admin/wp-admin-wc-settings-tax';
+import WPAdminWCSettingsTaxRates from './pages/wp-admin/wp-admin-wc-settings-tax-rates';
 import WPAdminWCSettingsProductsGeneral from './pages/wp-admin/wp-admin-wc-settings-products-general';
 import WPAdminWCSettingsProductsDownloadable from './pages/wp-admin/wp-admin-wc-settings-products-downloadable';
 import StoreOwnerFlow from './flows/store-owner-flow';
@@ -44,6 +45,7 @@ export {
 	WPAdminWCSettings,
 	WPAdminWCSettingsGeneral,
 	WPAdminWCSettingsTax,
+	WPAdminWCSettingsTaxRates,
 	WPAdminWCSettingsProductsDownloadable,
 	WPAdminWCSettingsProductsGeneral,
 	StoreOwnerFlow,

--- a/src/index.js
+++ b/src/index.js
@@ -18,6 +18,7 @@ import ShopPage from './pages/shop-page';
 import WPAdminProductNew from './pages/wp-admin/wp-admin-product-new';
 import WPAdminWCSettings from './pages/wp-admin/wp-admin-wc-settings';
 import WPAdminWCSettingsGeneral from './pages/wp-admin/wp-admin-wc-settings-general';
+import WPAdminWCSettingsTax from './pages/wp-admin/wp-admin-wc-settings-tax';
 import WPAdminWCSettingsProductsGeneral from './pages/wp-admin/wp-admin-wc-settings-products-general';
 import WPAdminWCSettingsProductsDownloadable from './pages/wp-admin/wp-admin-wc-settings-products-downloadable';
 import StoreOwnerFlow from './flows/store-owner-flow';
@@ -42,6 +43,7 @@ export {
 	WPAdminProductNew,
 	WPAdminWCSettings,
 	WPAdminWCSettingsGeneral,
+	WPAdminWCSettingsTax,
 	WPAdminWCSettingsProductsDownloadable,
 	WPAdminWCSettingsProductsGeneral,
 	StoreOwnerFlow,

--- a/src/page-map.js
+++ b/src/page-map.js
@@ -18,6 +18,7 @@ import WPAdminOrders from './pages/wp-admin/wp-admin-orders';
 import WPAdminCouponEdit from './pages/wp-admin/wp-admin-coupon-edit';
 import WPAdminCouponNew from './pages/wp-admin/wp-admin-coupon-new';
 import WPAdminCoupons from './pages/wp-admin/wp-admin-coupons';
+import WPAdminWCSettingsTax from './pages/wp-admin/wp-admin-wc-settings-tax';
 import WPAdminWCSettingsGeneral from './pages/wp-admin/wp-admin-wc-settings-general';
 import WPAdminWCSettingsCheckout from './pages/wp-admin/wp-admin-wc-settings-checkout';
 import WPAdminWCSettingsCheckoutBACS from './pages/wp-admin/wp-admin-wc-settings-checkout-bacs';
@@ -79,6 +80,10 @@ export const PAGE = Object.assign(
 			object: WPAdminWCSettingsGeneral,
 			path: '/wp-admin/admin.php?page=wc-settings'
 		},
+		WP_ADMIN_WC_SETTINGS_TAX: {
+ 			object: WPAdminWCSettingsTax,
+ 			path: '/wp-admin/admin.php?page=wc-settings&tab=tax'
+ 		},
 		WP_ADMIN_WC_SETTINGS_CHECKOUT: {
 			object: WPAdminWCSettingsCheckout,
 			path: '/wp-admin/admin.php?page=wc-settings&tab=checkout'

--- a/src/pages/wp-admin/wp-admin-wc-settings-tax-rates.js
+++ b/src/pages/wp-admin/wp-admin-wc-settings-tax-rates.js
@@ -46,7 +46,7 @@ export default class WPAdminWCSettingsTaxRates extends WPAdminWCSettings {
  	* @return {Promise}   Promise that evaluates to `true` if set successfully, `false` otherwise.
 	*/
 	setCountryCode( row, value ) {
-		return helper.setWhenSettable( this.driver, this._getSelector( row, '.wc_input_country_iso' ), value );
+		return helper.setWhenSettable( this.driver, this.getSelector( row, '.wc_input_country_iso' ), value );
 	}
 
 	/**
@@ -57,7 +57,7 @@ export default class WPAdminWCSettingsTaxRates extends WPAdminWCSettings {
  	* @return {Promise}   Promise that evaluates to `true` if set successfully, `false` otherwise.
 	*/
 	setStateCode( row, value ) {
-		return helper.setWhenSettable( this.driver, this._getSelector( row, '.state input' ), value );
+		return helper.setWhenSettable( this.driver, this.getSelector( row, '.state input' ), value );
 	}
 
 	/**
@@ -68,7 +68,7 @@ export default class WPAdminWCSettingsTaxRates extends WPAdminWCSettings {
  	* @return {Promise}   Promise that evaluates to `true` if set successfully, `false` otherwise.
 	*/
 	setZipCode( row, value ) {
-		return helper.setWhenSettable( this.driver, this._getSelector( row, '.postcode input' ), value );
+		return helper.setWhenSettable( this.driver, this.getSelector( row, '.postcode input' ), value );
 	}
 
 	/**
@@ -79,7 +79,7 @@ export default class WPAdminWCSettingsTaxRates extends WPAdminWCSettings {
  	* @return {Promise}   Promise that evaluates to `true` if set successfully, `false` otherwise.
 	*/
 	setCity( row, value ) {
-		return helper.setWhenSettable( this.driver, this._getSelector( row, '.city input' ), value );
+		return helper.setWhenSettable( this.driver, this.getSelector( row, '.city input' ), value );
 	}
 
 	/**
@@ -90,7 +90,7 @@ export default class WPAdminWCSettingsTaxRates extends WPAdminWCSettings {
  	* @return {Promise}   Promise that evaluates to `true` if set successfully, `false` otherwise.
 	*/
 	setRate( row, value ) {
-		return helper.setWhenSettable( this.driver, this._getSelector( row, '.rate input' ), value );
+		return helper.setWhenSettable( this.driver, this.getSelector( row, '.rate input' ), value );
 	}
 
 	/**
@@ -101,7 +101,7 @@ export default class WPAdminWCSettingsTaxRates extends WPAdminWCSettings {
  	* @return {Promise}   Promise that evaluates to `true` if set successfully, `false` otherwise.
 	*/
 	setTaxName( row, value ) {
-		return helper.setWhenSettable( this.driver, this._getSelector( row, '.name input' ), value );
+		return helper.setWhenSettable( this.driver, this.getSelector( row, '.name input' ), value );
 	}
 
 	/**
@@ -112,7 +112,7 @@ export default class WPAdminWCSettingsTaxRates extends WPAdminWCSettings {
  	* @return {Promise}   Promise that evaluates to `true` if set successfully, `false` otherwise.
 	*/
 	setPriority( row, value ) {
-		return helper.setWhenSettable( this.driver, this._getSelector( row, '.priority input' ), value );
+		return helper.setWhenSettable( this.driver, this.getSelector( row, '.priority input' ), value );
 	}
 
 	/**
@@ -122,7 +122,7 @@ export default class WPAdminWCSettingsTaxRates extends WPAdminWCSettings {
  	* @return {Promise}   Promise that evaluates to `true` if box is/gets checked successfully, `false` otherwise.
 	*/
 	checkCompound( row ) {
-		const selector = this._getSelector( row, '.compound input' );
+		const selector = this.getSelector( row, '.compound input' );
 		helper.unsetCheckbox( this.driver, selector );
 		return helper.setCheckbox( this.driver, selector );
 	}
@@ -134,7 +134,7 @@ export default class WPAdminWCSettingsTaxRates extends WPAdminWCSettings {
  	* @return {Promise}   Promise that evaluates to `true` if box is/gets unchecked successfully, `false` otherwise.
 	*/
 	uncheckCompound( row ) {
-		const selector = this._getSelector( row, '.compound input' );
+		const selector = this.getSelector( row, '.compound input' );
 		helper.setCheckbox( this.driver, selector );
 		return helper.unsetCheckbox( this.driver, selector );
 	}
@@ -146,7 +146,7 @@ export default class WPAdminWCSettingsTaxRates extends WPAdminWCSettings {
  	* @return {Promise}   Promise that evaluates to `true` if box is/gets checked successfully, `false` otherwise.
 	*/
 	checkShipping( row ) {
-		const selector = this._getSelector( row, '.apply_to_shipping input' );
+		const selector = this.getSelector( row, '.apply_to_shipping input' );
 		helper.unsetCheckbox( this.driver, selector );
 		return helper.setCheckbox( this.driver, selector );
 	}
@@ -158,7 +158,7 @@ export default class WPAdminWCSettingsTaxRates extends WPAdminWCSettings {
  	* @return {Promise}   Promise that evaluates to `true` if box is/gets unchecked successfully, `false` otherwise.
 	*/
 	uncheckShipping( row ) {
-		const selector = this._getSelector( row, '.apply_to_shipping input' );
+		const selector = this.getSelector( row, '.apply_to_shipping input' );
 		helper.setCheckbox( this.driver, selector );
 		return helper.unsetCheckbox( this.driver, selector );
 	}
@@ -188,7 +188,7 @@ export default class WPAdminWCSettingsTaxRates extends WPAdminWCSettings {
  	* @return {Promise}   Promise that evaluates to `true` if row removed successfully using UI, `false` otherwise.
 	*/
 	removeRow( row ) {
-		return helper.clickWhenClickable( this.driver, this._getSelector( row, '.wc_input_country_iso' ) ).then(
+		return helper.clickWhenClickable( this.driver, this.getSelector( row, '.wc_input_country_iso' ) ).then(
 			() => {
 				return this.removeSelectedRows();
 			}
@@ -196,12 +196,13 @@ export default class WPAdminWCSettingsTaxRates extends WPAdminWCSettings {
 	}
 
 	/**
-	 * Get the selector for an element in the tax rate form. (Internal use only)
+	 * Get the selector for an element in the tax rate form.
 	 *
 	 * @param  {int}       row - Row number element is in.
 	 * @param  {string}    child_el - An optional CSS selector to look for inside the row. Default: ''
+	 * @return {object}    selector
 	 */
-	_getSelector( row, child_el = '' ) {
+	getSelector( row, child_el = '' ) {
 		return By.css( `#rates tr:nth-child(${ row }) ${ child_el }` );
 	}
 }

--- a/src/pages/wp-admin/wp-admin-wc-settings-tax-rates.js
+++ b/src/pages/wp-admin/wp-admin-wc-settings-tax-rates.js
@@ -1,0 +1,125 @@
+/**
+ * @module WPAdminWCSettingsTaxRates
+ */
+
+/**
+ * External dependencies
+ */
+import { By } from 'selenium-webdriver';
+import { WebDriverHelper as helper } from 'wp-e2e-webdriver';
+
+/**
+ * Internal Dependencies
+ */
+import * as wcHelper from '../../helper';
+import WPAdminWCSettings from './wp-admin-wc-settings';
+/*
+const CALCULATE_TAX_BASED_ON_SELECTOR = wcHelper.getSelect2ToggleSelectorByName( 'woocommerce_tax_based_on' );
+const SHIPPING_TAX_CLASS_SELECTOR = wcHelper.getSelect2ToggleSelectorByName( 'woocommerce_shipping_tax_class' );
+const ROUNDING_SELECTOR = By.css( '#woocommerce_tax_round_at_subtotal' );
+const ADDITIONAL_TAX_CLASSES_SELECTOR = By.css( '#woocommerce_tax_classes' );
+const DISPLAY_PRICES_IN_THE_SHOP_SELECTOR = wcHelper.getSelect2ToggleSelectorByName( 'woocommerce_tax_display_shop' );
+const DISPLAY_PRICES_DURING_CART_CHECKOUT_SELECTOR = wcHelper.getSelect2ToggleSelectorByName( 'woocommerce_tax_display_cart' );
+const PRICE_DISPLAY_SUFFIX_SELECTOR = By.css( '#woocommerce_price_display_suffix' );
+const DISPLAY_TAX_TOTALS_SELECTOR = wcHelper.getSelect2ToggleSelectorByName( 'woocommerce_tax_total_display' );
+*/
+const INSERT_ROW_SELECTOR = By.css( '.button.insert' );
+const REMOVE_SELECTED_ROWS_SELECTOR = By.css( '.button.remove_tax_rates' );
+
+const defaultArgs = {
+	url: '',
+	visit: true,
+};
+
+/**
+ * A Tax: Standard/other rates settings screen.
+ *
+ * @extends WPAdminWCSettings
+ */
+export default class WPAdminWCSettingsTaxRates extends WPAdminWCSettings {
+
+	/**
+ 	* @param {WebDriver} driver   - Instance of WebDriver.
+ 	* @param {object}    args     - Configuration arguments.
+	*/
+	constructor( driver, args = {} ) {
+		args = Object.assign( defaultArgs, args );
+		super( driver, args );
+	}
+
+	_getSelector( row, child_el = '' ) {
+		return By.css( `#rates tr:nth-child(${ row }) ${ child_el }` );
+	}
+
+	setCountryCode( row, value ) {
+		return helper.setWhenSettable( this.driver, this._getSelector( row, '.wc_input_country_iso' ), value );
+	}
+
+	setStateCode( row, value ) {
+		return helper.setWhenSettable( this.driver, this._getSelector( row, '.state input' ), value );
+	}
+
+	setZipCode( row, value ) {
+		return helper.setWhenSettable( this.driver, this._getSelector( row, '.postcode input' ), value );
+	}
+
+	setCity( row, value ) {
+		return helper.setWhenSettable( this.driver, this._getSelector( row, '.city input' ), value );
+	}
+
+	setRate( row, value ) {
+		return helper.setWhenSettable( this.driver, this._getSelector( row, '.rate input' ), value );
+	}
+
+	setTaxName( row, value ) {
+		return helper.setWhenSettable( this.driver, this._getSelector( row, '.name input' ), value );
+	}
+
+	setPriority( row, value ) {
+		return helper.setWhenSettable( this.driver, this._getSelector( row, '.priority input' ), value );
+	}
+
+	checkCompound( row ) {
+		const selector = this._getSelector( row, '.compound input' );
+		helper.unsetCheckbox( this.driver, selector );
+		return helper.setCheckbox( this.driver, selector );
+	}
+
+	uncheckCompound( row ) {
+		const selector = this._getSelector( row, '.compound input' );
+		helper.setCheckbox( this.driver, selector );
+		return helper.unsetCheckbox( this.driver, selector );
+	}
+
+	checkShipping( row ) {
+		const selector = this._getSelector( row, '.apply_to_shipping input' );
+		helper.unsetCheckbox( this.driver, selector );
+		return helper.setCheckbox( this.driver, selector );
+	}
+
+	uncheckShipping( row ) {
+		const selector = this._getSelector( row, '.apply_to_shipping input' );
+		helper.setCheckbox( this.driver, selector );
+		return helper.unsetCheckbox( this.driver, selector );
+	}
+
+	insertRow() {
+		return helper.clickWhenClickable( this.driver, INSERT_ROW_SELECTOR );
+	}
+
+	removeSelectedRows() {
+		return helper.clickWhenClickable( this.driver, REMOVE_SELECTED_ROWS_SELECTOR );
+	}
+
+	removeRow( row ) {
+		var self = this;
+		return helper.clickWhenClickable( this.driver, this._getSelector( row, '.wc_input_country_iso' ) ).then(
+			function() {
+				return self.removeSelectedRows();
+			}
+		);
+	}
+
+	//removeRow
+
+}

--- a/src/pages/wp-admin/wp-admin-wc-settings-tax-rates.js
+++ b/src/pages/wp-admin/wp-admin-wc-settings-tax-rates.js
@@ -13,16 +13,7 @@ import { WebDriverHelper as helper } from 'wp-e2e-webdriver';
  */
 import * as wcHelper from '../../helper';
 import WPAdminWCSettings from './wp-admin-wc-settings';
-/*
-const CALCULATE_TAX_BASED_ON_SELECTOR = wcHelper.getSelect2ToggleSelectorByName( 'woocommerce_tax_based_on' );
-const SHIPPING_TAX_CLASS_SELECTOR = wcHelper.getSelect2ToggleSelectorByName( 'woocommerce_shipping_tax_class' );
-const ROUNDING_SELECTOR = By.css( '#woocommerce_tax_round_at_subtotal' );
-const ADDITIONAL_TAX_CLASSES_SELECTOR = By.css( '#woocommerce_tax_classes' );
-const DISPLAY_PRICES_IN_THE_SHOP_SELECTOR = wcHelper.getSelect2ToggleSelectorByName( 'woocommerce_tax_display_shop' );
-const DISPLAY_PRICES_DURING_CART_CHECKOUT_SELECTOR = wcHelper.getSelect2ToggleSelectorByName( 'woocommerce_tax_display_cart' );
-const PRICE_DISPLAY_SUFFIX_SELECTOR = By.css( '#woocommerce_price_display_suffix' );
-const DISPLAY_TAX_TOTALS_SELECTOR = wcHelper.getSelect2ToggleSelectorByName( 'woocommerce_tax_total_display' );
-*/
+
 const INSERT_ROW_SELECTOR = By.css( '.button.insert' );
 const REMOVE_SELECTED_ROWS_SELECTOR = By.css( '.button.remove_tax_rates' );
 
@@ -47,79 +38,170 @@ export default class WPAdminWCSettingsTaxRates extends WPAdminWCSettings {
 		super( driver, args );
 	}
 
-	_getSelector( row, child_el = '' ) {
-		return By.css( `#rates tr:nth-child(${ row }) ${ child_el }` );
-	}
-
+	/**
+	* Set the Country Code field.
+	*
+	* @param  {int}       row - Row number to set field for.
+ 	* @param  {string}    value - Country code.
+ 	* @return {Promise}   Promise that evaluates to `true` if set successfully, `false` otherwise.
+	*/
 	setCountryCode( row, value ) {
 		return helper.setWhenSettable( this.driver, this._getSelector( row, '.wc_input_country_iso' ), value );
 	}
 
+	/**
+	* Set the State Code field.
+	*
+	* @param  {int}       row - Row number to set field for.
+ 	* @param  {string}    value - State code.
+ 	* @return {Promise}   Promise that evaluates to `true` if set successfully, `false` otherwise.
+	*/
 	setStateCode( row, value ) {
 		return helper.setWhenSettable( this.driver, this._getSelector( row, '.state input' ), value );
 	}
 
+	/**
+	* Set the Postcode/Zip field.
+	*
+	* @param  {int}       row - Row number to set field for.
+ 	* @param  {string}    value - Zip or postal code.
+ 	* @return {Promise}   Promise that evaluates to `true` if set successfully, `false` otherwise.
+	*/
 	setZipCode( row, value ) {
 		return helper.setWhenSettable( this.driver, this._getSelector( row, '.postcode input' ), value );
 	}
 
+	/**
+	* Set the City field.
+	*
+	* @param  {int}       row - Row number to set field for.
+ 	* @param  {string}    value - City.
+ 	* @return {Promise}   Promise that evaluates to `true` if set successfully, `false` otherwise.
+	*/
 	setCity( row, value ) {
 		return helper.setWhenSettable( this.driver, this._getSelector( row, '.city input' ), value );
 	}
 
+	/**
+	* Set the Rate % field.
+	*
+	* @param  {int}       row - Row number to set field for.
+ 	* @param  {string}    value - Rate %.
+ 	* @return {Promise}   Promise that evaluates to `true` if set successfully, `false` otherwise.
+	*/
 	setRate( row, value ) {
 		return helper.setWhenSettable( this.driver, this._getSelector( row, '.rate input' ), value );
 	}
 
+	/**
+	* Set the Tax Name field.
+	*
+	* @param  {int}       row - Row number to set field for.
+ 	* @param  {string}    value - Tax name.
+ 	* @return {Promise}   Promise that evaluates to `true` if set successfully, `false` otherwise.
+	*/
 	setTaxName( row, value ) {
 		return helper.setWhenSettable( this.driver, this._getSelector( row, '.name input' ), value );
 	}
 
+	/**
+	* Set the Priority field.
+	*
+	* @param  {int}       row - Row number to set field for.
+ 	* @param  {string}    value - Priority.
+ 	* @return {Promise}   Promise that evaluates to `true` if set successfully, `false` otherwise.
+	*/
 	setPriority( row, value ) {
 		return helper.setWhenSettable( this.driver, this._getSelector( row, '.priority input' ), value );
 	}
 
+	/**
+	* Check the "Compound" checkbox.
+	*
+	* @param  {int}       row - Row number of checkbox.
+ 	* @return {Promise}   Promise that evaluates to `true` if box is/gets checked successfully, `false` otherwise.
+	*/
 	checkCompound( row ) {
 		const selector = this._getSelector( row, '.compound input' );
 		helper.unsetCheckbox( this.driver, selector );
 		return helper.setCheckbox( this.driver, selector );
 	}
 
+	/**
+	* Uncheck the "Compound" checkbox.
+	*
+	* @param  {int}       row - Row number of checkbox.
+ 	* @return {Promise}   Promise that evaluates to `true` if box is/gets unchecked successfully, `false` otherwise.
+	*/
 	uncheckCompound( row ) {
 		const selector = this._getSelector( row, '.compound input' );
 		helper.setCheckbox( this.driver, selector );
 		return helper.unsetCheckbox( this.driver, selector );
 	}
 
+	/**
+	* Check the "Shipping" checkbox.
+	*
+	* @param  {int}       row - Row number of checkbox.
+ 	* @return {Promise}   Promise that evaluates to `true` if box is/gets checked successfully, `false` otherwise.
+	*/
 	checkShipping( row ) {
 		const selector = this._getSelector( row, '.apply_to_shipping input' );
 		helper.unsetCheckbox( this.driver, selector );
 		return helper.setCheckbox( this.driver, selector );
 	}
 
+	/**
+	* Uncheck the "Compound" checkbox.
+	*
+	* @param  {int}       row - Row number of checkbox.
+ 	* @return {Promise}   Promise that evaluates to `true` if box is/gets unchecked successfully, `false` otherwise.
+	*/
 	uncheckShipping( row ) {
 		const selector = this._getSelector( row, '.apply_to_shipping input' );
 		helper.setCheckbox( this.driver, selector );
 		return helper.unsetCheckbox( this.driver, selector );
 	}
 
+	/**
+	* Click the "Insert Row" button.
+	*
+ 	* @return {Promise}   Promise that evaluates to `true` if button gets clicked successfully, `false` otherwise.
+	*/
 	insertRow() {
 		return helper.clickWhenClickable( this.driver, INSERT_ROW_SELECTOR );
 	}
 
+	/**
+	* Click the "Remove Selected Row(s)" button.
+	*
+ 	* @return {Promise}   Promise that evaluates to `true` if button gets clicked successfully, `false` otherwise.
+	*/
 	removeSelectedRows() {
 		return helper.clickWhenClickable( this.driver, REMOVE_SELECTED_ROWS_SELECTOR );
 	}
 
+	/**
+	* Remove a row.
+	*
+	* @param  {int}       row - Row number to remove.
+ 	* @return {Promise}   Promise that evaluates to `true` if row removed successfully using UI, `false` otherwise.
+	*/
 	removeRow( row ) {
-		var self = this;
 		return helper.clickWhenClickable( this.driver, this._getSelector( row, '.wc_input_country_iso' ) ).then(
-			function() {
-				return self.removeSelectedRows();
+			() => {
+				return this.removeSelectedRows();
 			}
 		);
 	}
 
-	//removeRow
-
+	/**
+	 * Get the selector for an element in the tax rate form. (Internal use only)
+	 *
+	 * @param  {int}       row - Row number element is in.
+	 * @param  {string}    child_el - An optional CSS selector to look for inside the row. Default: ''
+	 */
+	_getSelector( row, child_el = '' ) {
+		return By.css( `#rates tr:nth-child(${ row }) ${ child_el }` );
+	}
 }

--- a/src/pages/wp-admin/wp-admin-wc-settings-tax.js
+++ b/src/pages/wp-admin/wp-admin-wc-settings-tax.js
@@ -1,4 +1,8 @@
 /**
+ * @module WPAdminWCSettingsTax
+ */
+
+/**
  * External dependencies
  */
 import { By } from 'selenium-webdriver';
@@ -24,16 +28,25 @@ const defaultArgs = {
 	visit: true,
 };
 
+/**
+ * The Tax: Tax Options settings screen.
+ *
+ * @extends WPAdminWCSettings
+ */
 export default class WPAdminWCSettingsTax extends WPAdminWCSettings {
 
+	/**
+ 	* @param {WebDriver} driver   - Instance of WebDriver.
+ 	* @param {object}    args     - Configuration arguments.
+	*/
 	constructor( driver, args = {} ) {
 		args = Object.assign( defaultArgs, args );
 		super( driver, args );
 	}
 
 	/**
-	* Set the "Prices entered with tax" option to "Yes"
-	* @return {Promise}
+	* Set the "Prices entered with tax" option to "Yes".
+ 	* @return {Promise}   Promise that evaluates to `true` if set selected successfully, `false` otherwise.
 	*/
 	selectPricesEnteredWithTax() {
 		const selector = this._getPriceEnteredWithTaxSelector( 'yes' );
@@ -41,40 +54,69 @@ export default class WPAdminWCSettingsTax extends WPAdminWCSettings {
 	}
 
 	/**
-	* Set the "Prices entered with tax" option to "No"
-	* @return {Promise}
+	* Set the "Prices entered with tax" option to "No".
+ 	* @return {Promise}   Promise that evaluates to `true` if set selected successfully, `false` otherwise.
 	*/
 	selectPricesEnteredWithNoTax() {
 		const selector = this._getPriceEnteredWithTaxSelector( 'no' );
 		return helper.clickWhenClickable( this.driver, selector );
 	}
 
-	_getPriceEnteredWithTaxSelector( option ) {
-		return By.css( `input[name="woocommerce_prices_include_tax"][value="${ option }"]` );
-	}
-
+	/**
+	* Select the weight unit.
+	*
+ 	* @param  {string}    option - Text for option to select.
+ 	* @return {Promise}   Promise that evaluates to `true` if selected successfully, `false` otherwise.
+	*/
 	selectCalculateTaxBasedOn( option ) {
 		return wcHelper.select2Option( this.driver, CALCULATE_TAX_BASED_ON_SELECTOR, option );
 	}
 
+	/**
+	* Select the shipping tax class.
+	*
+ 	* @param  {string}    option - Text for option to select.
+ 	* @return {Promise}   Promise that evaluates to `true` if selected successfully, `false` otherwise.
+	*/
 	selectShippingTaxClass( option ) {
 		return wcHelper.select2Option( this.driver, SHIPPING_TAX_CLASS_SELECTOR, option );
 	}
 
+	/**
+	* Check the "Rounding" checkbox.
+	*
+ 	* @return {Promise}   Promise that evaluates to `true` if box is/gets checked successfully, `false` otherwise.
+	*/
 	checkRounding() {
 		helper.unsetCheckbox( this.driver, ROUNDING_SELECTOR );
 		return helper.setCheckbox( this.driver, ROUNDING_SELECTOR );
 	}
 
+	/**
+	* Uncheck the "Rounding" checkbox.
+	*
+ 	* @return {Promise}   Promise that evaluates to `true` if box is/gets unchecked successfully, `false` otherwise.
+	*/
 	uncheckRounding() {
 		helper.setCheckbox( this.driver, ROUNDING_SELECTOR );
 		return helper.unsetCheckbox( this.driver, ROUNDING_SELECTOR );
 	}
 
+	/**
+	* Remove all of the additional tax classes from the additional tax class field.
+	*
+ 	* @return {Promise}   Promise that evaluates to `true` if input found and set successfully, `false` otherwise.
+	*/
 	removeAdditionalTaxClasses() {
 		helper.setWhenSettable( this.driver, ADDITIONAL_TAX_CLASSES_SELECTOR, "" );
 	}
 
+	/**
+	* Add an additional tax class to the additional tax class field.
+	*
+	* @param  {string}    value - Tax class to add
+ 	* @return {Promise}   Promise that evaluates to `true` if input found and class added successfully, `false` otherwise.
+	*/
 	addAdditionalTaxClass( value ) {
 		const driver = this.driver;
 
@@ -90,6 +132,12 @@ export default class WPAdminWCSettingsTax extends WPAdminWCSettings {
 		);
 	}
 
+	/**
+	* Remove an additional tax class from the additional tax class field.
+	*
+	* @param  {string}    value - Tax class to remove
+ 	* @return {Promise}   Promise that evaluates to `true` if input found and class removed successfully, `false` otherwise.
+	*/
 	removeAdditionalTaxClass( value ) {
 		const driver = this.driver;
 
@@ -105,21 +153,55 @@ export default class WPAdminWCSettingsTax extends WPAdminWCSettings {
 		);
 	}
 
+	/**
+	* Select the "Display prices in the shop" option.
+	*
+ 	* @param  {string}    option - Text for option to select.
+ 	* @return {Promise}   Promise that evaluates to `true` if selected successfully, `false` otherwise.
+	*/
 	selectDisplayPricesInTheShop( option ) {
 		return wcHelper.select2Option( this.driver, DISPLAY_PRICES_IN_THE_SHOP_SELECTOR, option );
 
 	}
 
+	/**
+	* Select the "Display prices during cart and checkout" option.
+	*
+ 	* @param  {string}    option - Text for option to select.
+ 	* @return {Promise}   Promise that evaluates to `true` if selected successfully, `false` otherwise.
+	*/
 	selectDisplayPricesDuringCartAndCheckout( option ) {
 		return wcHelper.select2Option( this.driver, DISPLAY_PRICES_DURING_CART_CHECKOUT_SELECTOR, option );
 
 	}
 
+	/**
+	* Set the price display suffix field.
+	*
+ 	* @param  {string}    value - Price display suffix.
+ 	* @return {Promise}   Promise that evaluates to `true` if set successfully, `false` otherwise.
+	*/
 	setPriceDisplaySuffix( value ) {
 		return helper.setWhenSettable( this.driver, PRICE_DISPLAY_SUFFIX_SELECTOR, value );
 	}
 
+	/**
+	* Select the "Display tax totals" option.
+	*
+ 	* @param  {string}    option - Text for option to select.
+ 	* @return {Promise}   Promise that evaluates to `true` if selected successfully, `false` otherwise.
+	*/
 	selectDisplayTaxTotals( option ) {
 		return wcHelper.select2Option( this.driver, DISPLAY_TAX_TOTALS_SELECTOR, option );
+	}
+
+	/**
+	* Get a selector for a "Prices entered with tax" radio option. (Internal use only)
+	*
+ 	* @param  {string}    option - Text for option to select.
+ 	* @return {object}    Selector.
+	*/
+	_getPriceEnteredWithTaxSelector( option ) {
+		return By.css( `input[name="woocommerce_prices_include_tax"][value="${ option }"]` );
 	}
 }

--- a/src/pages/wp-admin/wp-admin-wc-settings-tax.js
+++ b/src/pages/wp-admin/wp-admin-wc-settings-tax.js
@@ -1,0 +1,125 @@
+/**
+ * External dependencies
+ */
+import { By } from 'selenium-webdriver';
+import { WebDriverHelper as helper } from 'wp-e2e-webdriver';
+
+/**
+ * Internal Dependencies
+ */
+import * as wcHelper from '../../helper';
+import WPAdminWCSettings from './wp-admin-wc-settings';
+
+const CALCULATE_TAX_BASED_ON_SELECTOR = wcHelper.getSelect2ToggleSelectorByName( 'woocommerce_tax_based_on' );
+const SHIPPING_TAX_CLASS_SELECTOR = wcHelper.getSelect2ToggleSelectorByName( 'woocommerce_shipping_tax_class' );
+const ROUNDING_SELECTOR = By.css( '#woocommerce_tax_round_at_subtotal' );
+const ADDITIONAL_TAX_CLASSES_SELECTOR = By.css( '#woocommerce_tax_classes' );
+const DISPLAY_PRICES_IN_THE_SHOP_SELECTOR = wcHelper.getSelect2ToggleSelectorByName( 'woocommerce_tax_display_shop' );
+const DISPLAY_PRICES_DURING_CART_CHECKOUT_SELECTOR = wcHelper.getSelect2ToggleSelectorByName( 'woocommerce_tax_display_cart' );
+const PRICE_DISPLAY_SUFFIX_SELECTOR = By.css( '#woocommerce_price_display_suffix' );
+const DISPLAY_TAX_TOTALS_SELECTOR = wcHelper.getSelect2ToggleSelectorByName( 'woocommerce_tax_total_display' );
+
+const defaultArgs = {
+	url: '',
+	visit: true,
+};
+
+export default class WPAdminWCSettingsTax extends WPAdminWCSettings {
+
+	constructor( driver, args = {} ) {
+		args = Object.assign( defaultArgs, args );
+		super( driver, args );
+	}
+
+	/**
+	* Set the "Prices entered with tax" option to "Yes"
+	* @return {Promise}
+	*/
+	selectPricesEnteredWithTax() {
+		const selector = this._getPriceEnteredWithTaxSelector( 'yes' );
+		return helper.clickWhenClickable( this.driver, selector );
+	}
+
+	/**
+	* Set the "Prices entered with tax" option to "No"
+	* @return {Promise}
+	*/
+	selectPricesEnteredWithNoTax() {
+		const selector = this._getPriceEnteredWithTaxSelector( 'no' );
+		return helper.clickWhenClickable( this.driver, selector );
+	}
+
+	_getPriceEnteredWithTaxSelector( option ) {
+		return By.css( `input[name="woocommerce_prices_include_tax"][value="${ option }"]` );
+	}
+
+	selectCalculateTaxBasedOn( option ) {
+		return wcHelper.select2Option( this.driver, CALCULATE_TAX_BASED_ON_SELECTOR, option );
+	}
+
+	selectShippingTaxClass( option ) {
+		return wcHelper.select2Option( this.driver, SHIPPING_TAX_CLASS_SELECTOR, option );
+	}
+
+	checkRounding() {
+		helper.unsetCheckbox( this.driver, ROUNDING_SELECTOR );
+		return helper.setCheckbox( this.driver, ROUNDING_SELECTOR );
+	}
+
+	uncheckRounding() {
+		helper.setCheckbox( this.driver, ROUNDING_SELECTOR );
+		return helper.unsetCheckbox( this.driver, ROUNDING_SELECTOR );
+	}
+
+	removeAdditionalTaxClasses() {
+		helper.setWhenSettable( this.driver, ADDITIONAL_TAX_CLASSES_SELECTOR, "" );
+	}
+
+	addAdditionalTaxClass( value ) {
+		const driver = this.driver;
+
+		return this.driver.findElement( ADDITIONAL_TAX_CLASSES_SELECTOR ).then(
+			function( element ) {
+				return element.getAttribute( 'value' ).then( ( el_value ) => {
+					return helper.setWhenSettable( driver, ADDITIONAL_TAX_CLASSES_SELECTOR, ( el_value + '\n' + value ).trim() );
+				} );
+			},
+			function() {
+				return false;
+			}
+		);
+	}
+
+	removeAdditionalTaxClass( value ) {
+		const driver = this.driver;
+
+		return this.driver.findElement( ADDITIONAL_TAX_CLASSES_SELECTOR ).then(
+			function( element ) {
+				return element.getAttribute( 'value' ).then( ( el_value ) => {
+					return helper.setWhenSettable( driver, ADDITIONAL_TAX_CLASSES_SELECTOR, el_value.replace( new RegExp( `${value}\n?` ), '' ) );
+				} );
+			},
+			function() {
+				return false;
+			}
+		);
+	}
+
+	selectDisplayPricesInTheShop( option ) {
+		return wcHelper.select2Option( this.driver, DISPLAY_PRICES_IN_THE_SHOP_SELECTOR, option );
+
+	}
+
+	selectDisplayPricesDuringCartAndCheckout( option ) {
+		return wcHelper.select2Option( this.driver, DISPLAY_PRICES_DURING_CART_CHECKOUT_SELECTOR, option );
+
+	}
+
+	setPriceDisplaySuffix( value ) {
+		return helper.setWhenSettable( this.driver, PRICE_DISPLAY_SUFFIX_SELECTOR, value );
+	}
+
+	selectDisplayTaxTotals( option ) {
+		return wcHelper.select2Option( this.driver, DISPLAY_TAX_TOTALS_SELECTOR, option );
+	}
+}

--- a/src/pages/wp-admin/wp-admin-wc-settings.js
+++ b/src/pages/wp-admin/wp-admin-wc-settings.js
@@ -41,7 +41,7 @@ export default class WPAdminWCSettings extends WPAdminSettings {
  	* @return {Promise}   Promise that evaluates to `true` if sub-tab is present and displayed, `false` otherwise.
 	*/
 	hasSubTab( subTab ) {
-		return helper.isEventuallyPresentAndDisplayed( this.driver, this._getSubTabSelector( subTab ) );
+		return helper.isEventuallyPresentAndDisplayed( this.driver, this._getSubTabSelector( subTab, { active: false } ) );
 	}
 
 	/**
@@ -108,11 +108,11 @@ export default class WPAdminWCSettings extends WPAdminSettings {
  	* @return {object}    Selector object.
 	*/
 	_getSubTabSelector( subTab, { active = false } ) {
-		let exp = `//ul[contains(@class, "subsubsub")]/li/a[contains(text(), ${ subTab })]`;
+		let exp = `//ul[contains(@class, "subsubsub")]/li/a[contains(text(), "${ subTab }")]`;
 		if ( active ) {
 			exp = `//ul[contains(@class, "subsubsub")]/li/a[contains(@class, "current") and contains(text(), "${ subTab }")]`;
 		}
-
+console.log( exp );
 		return By.xpath( exp );
 	}
 }

--- a/src/pages/wp-admin/wp-admin-wc-settings.js
+++ b/src/pages/wp-admin/wp-admin-wc-settings.js
@@ -112,7 +112,6 @@ export default class WPAdminWCSettings extends WPAdminSettings {
 		if ( active ) {
 			exp = `//ul[contains(@class, "subsubsub")]/li/a[contains(@class, "current") and contains(text(), "${ subTab }")]`;
 		}
-console.log( exp );
 		return By.xpath( exp );
 	}
 }

--- a/test/wp-admin/wp-admin-wc-settings-tax.js
+++ b/test/wp-admin/wp-admin-wc-settings-tax.js
@@ -35,7 +35,7 @@ test.describe( 'WooCommerce Tax Settings', function() {
 		const wpLogin = new WPLogin( driver, { url: manager.getPageUrl( '/wp-login.php' ) } );
 		wpLogin.login( config.get( 'users.admin.username' ), config.get( 'users.admin.password' ) );
 	} );
-/*
+
 	test.it( 'can set tax options', () => {
 		const settingsArgs = { url: manager.getPageUrl( '/wp-admin/admin.php?page=wc-settings&tab=tax' ) };
 		const settings = new WPAdminWCSettingsTax( driver, settingsArgs );
@@ -54,53 +54,50 @@ test.describe( 'WooCommerce Tax Settings', function() {
 		assert.eventually.ok( settings.hasNotice( 'Your settings have been saved.' ) );
 	} );
 
-	test.it( 'can add and remove tax classes', () => {
+	test.it( 'can add tax classes', () => {
 		const settingsArgs = { url: manager.getPageUrl( '/wp-admin/admin.php?page=wc-settings&tab=tax' ) };
 		const settings = new WPAdminWCSettingsTax( driver, settingsArgs );
 
 		settings.removeAdditionalTaxClasses();
 		settings.saveChanges();
 
-		settings.addAdditionalTaxClass( 'Fancy rate' );
+		settings.addAdditionalTaxClass( 'Fancy' );
 		settings.saveChanges();
 
-		assert.eventually.ok( settings.hasSubTab( 'Fancy rate rates' ) );
-
-		settings.removeAdditionalTaxClass( 'Fancy rate' );
-		settings.saveChanges();
-
-		assert.eventually.ifError( settings.hasSubTab( 'Fancy rate rates' ) );
+		assert.eventually.ok( settings.hasSubTab( 'Fancy rates' ) );
 	} );
-*/
-	test.it( 'can do something', () => {
-		const settingsArgs = { url: manager.getPageUrl( '/wp-admin/admin.php?page=wc-settings&tab=tax&section=standard' ) };
+
+	test.it( 'can set rate settings', () => {
+		const settingsArgs = { url: manager.getPageUrl( '/wp-admin/admin.php?page=wc-settings&tab=tax&section=fancy' ) };
 		const settings = new WPAdminWCSettingsTaxRates( driver, settingsArgs );
 
 		settings.insertRow();
-		settings.insertRow();
+		settings.setCountryCode( 1, 'US' );
+		settings.setStateCode( 1, 'CA' );
+		settings.setRate( 1, '7.5' );
+		settings.setTaxName( 1, 'CA State Tax' );
 
-		settings.setCountryCode( 1, 'us' );
-		settings.setCountryCode( 2, 'ar' );
-		settings.setStateCode( 2, 'ca' );
-		settings.setStateCode( 1, 'or' );
-		settings.setCity( 2, 'Portland' );
-		settings.setCity( 1, 'Somewhere' );
-		settings.setRate( 1, '12' );
-		settings.setRate( 2, '15' );
-		settings.setTaxName( 1, 'First' );
-		settings.setTaxName( 2, 'Cool tax' );
-		settings.setPriority( 1, '2' );
-		settings.setPriority( 2, '3' );
-		settings.checkCompound( 1 );
-		settings.checkCompound( 2 );
-		settings.uncheckCompound( 1 );
-		settings.uncheckCompound( 2 );
-		settings.checkShipping( 3 );
-		settings.uncheckShipping( 3 );
-		driver.sleep( 4000 );
+		settings.insertRow();
+		settings.setCountryCode( 2, 'US' );
+		settings.setRate( 2, '1.5' );
+		settings.setPriority( 2, '2' );
+		settings.setTaxName( 2, 'Federal Tax' );
+		settings.uncheckShipping( 2 );
+		settings.saveChanges();
 
 		settings.removeRow( 2 );
-		driver.sleep( 10000 );
+		settings.saveChanges();
+		assert.eventually.ifError( helper.isEventuallyPresentAndDisplayed( driver, settings.getSelector( 2 ), 1000 ) );
+	} );
+
+	test.it( 'can remove tax classes', () => {
+		const settingsArgs = { url: manager.getPageUrl( '/wp-admin/admin.php?page=wc-settings&tab=tax' ) };
+		const settings = new WPAdminWCSettingsTax( driver, settingsArgs );
+
+		settings.removeAdditionalTaxClass( 'Fancy' );
+		settings.saveChanges();
+
+		assert.eventually.ifError( settings.hasSubTab( 'Fancy rates' ) );
 	} );
 
 	test.after( 'quit browser', () => {

--- a/test/wp-admin/wp-admin-wc-settings-tax.js
+++ b/test/wp-admin/wp-admin-wc-settings-tax.js
@@ -35,7 +35,7 @@ test.describe( 'WooCommerce Tax Settings', function() {
 		const wpLogin = new WPLogin( driver, { url: manager.getPageUrl( '/wp-login.php' ) } );
 		wpLogin.login( config.get( 'users.admin.username' ), config.get( 'users.admin.password' ) );
 	} );
-
+/*
 	test.it( 'can set tax options', () => {
 		const settingsArgs = { url: manager.getPageUrl( '/wp-admin/admin.php?page=wc-settings&tab=tax' ) };
 		const settings = new WPAdminWCSettingsTax( driver, settingsArgs );
@@ -71,7 +71,7 @@ test.describe( 'WooCommerce Tax Settings', function() {
 
 		assert.eventually.ifError( settings.hasSubTab( 'Fancy rate rates' ) );
 	} );
-
+*/
 	test.it( 'can do something', () => {
 		const settingsArgs = { url: manager.getPageUrl( '/wp-admin/admin.php?page=wc-settings&tab=tax&section=standard' ) };
 		const settings = new WPAdminWCSettingsTaxRates( driver, settingsArgs );

--- a/test/wp-admin/wp-admin-wc-settings-tax.js
+++ b/test/wp-admin/wp-admin-wc-settings-tax.js
@@ -36,104 +36,40 @@ test.describe( 'WooCommerce Tax Settings', function() {
 		wpLogin.login( config.get( 'users.admin.username' ), config.get( 'users.admin.password' ) );
 	} );
 
-	test.it( 'can do something', () => {
+	test.it( 'can set tax options', () => {
 		const settingsArgs = { url: manager.getPageUrl( '/wp-admin/admin.php?page=wc-settings&tab=tax' ) };
 		const settings = new WPAdminWCSettingsTax( driver, settingsArgs );
 
 		assert.eventually.ok( settings.hasActiveTab( 'Tax' ) );
 
-		settings.selectPricesEnteredWithTax();
-		driver.sleep( 1000 );
-
 		settings.selectPricesEnteredWithNoTax();
-		driver.sleep( 1000 );
-
-		settings.checkRounding();
-		driver.sleep( 1000 );
-
-		settings.setPriceDisplaySuffix( 'inc. Vat' );
-		driver.sleep( 1000 );
-
-		settings.uncheckRounding();
-		driver.sleep( 1000 );
-
 		settings.selectCalculateTaxBasedOn( 'Customer shipping address' );
-		driver.sleep( 1000 );
-
-		settings.selectCalculateTaxBasedOn( 'Customer billing address' );
-		driver.sleep( 1000 );
-
-		settings.selectCalculateTaxBasedOn( 'Shop base address' );
-		driver.sleep( 1000 );
-
-		settings.selectDisplayPricesInTheShop( 'Including tax' );
-		driver.sleep( 1000 );
-
-		settings.selectDisplayTaxTotals( 'As a single total' );
-		driver.sleep( 1000 );
-
-		settings.setPriceDisplaySuffix( 'billz' );
-		driver.sleep( 1000 );
-
-		settings.selectDisplayPricesDuringCartAndCheckout( 'Excluding tax' );
-		driver.sleep( 1000 );
-
+		settings.selectShippingTaxClass( 'Standard' );
+		settings.uncheckRounding();
 		settings.selectDisplayPricesInTheShop( 'Excluding tax' );
-		driver.sleep( 1000 );
-
-		settings.selectDisplayTaxTotals( 'Itemized' );
-		driver.sleep( 1000 );
-
 		settings.selectDisplayPricesDuringCartAndCheckout( 'Including tax' );
-		driver.sleep( 1000 );
+		settings.selectDisplayTaxTotals( 'As a single total' );
 
-		settings.addAdditionalTaxClass( 'test class' );
-		driver.sleep( 1000 );
-
-		settings.removeAdditionalTaxClass( 'Zero rate' );
-		driver.sleep( 1000 );
-
-		settings.addAdditionalTaxClass( 'another one' );
-		driver.sleep( 1000 );
-
-		settings.addAdditionalTaxClass( 'lets start over' );
-		driver.sleep( 1000 );
-
-		settings.removeAdditionalTaxClass( 'lets start over' );
-		driver.sleep( 1000 );
-
-		settings.removeAdditionalTaxClass( 'test class' );
-		driver.sleep( 1000 );
-
-
-/*
-		// Set selling location to all countries first, so we can choose california
-		// as base location.
-		settings.selectSellingLocation( 'Sell to all countries' );
 		settings.saveChanges();
 		assert.eventually.ok( settings.hasNotice( 'Your settings have been saved.' ) );
+	} );
 
-		// Set base location with state CA.
-		settings.selectBaseLocation( 'california', 'United States (US) — California' );
+	test.it( 'can add and remove tax classes', () => {
+		const settingsArgs = { url: manager.getPageUrl( '/wp-admin/admin.php?page=wc-settings&tab=tax' ) };
+		const settings = new WPAdminWCSettingsTax( driver, settingsArgs );
+
+		settings.removeAdditionalTaxClasses();
 		settings.saveChanges();
-		assert.eventually.ok( settings.hasNotice( 'Your settings have been saved.' ) );
 
-		// Set selling location to specific countries first, so we can choose
-		// U.S as base location (without state). This will makes specific
-		// countries option appears.
-		settings.selectSellingLocation( 'Sell to specific countries' );
-		settings.removeChoiceInSellToSpecificCountries( 'United States (US)' );
-		settings.setSellToSpecificCountries( 'united states', 'United States (US)' );
+		settings.addAdditionalTaxClass( 'Fancy rate' );
 		settings.saveChanges();
-		assert.eventually.ok( settings.hasNotice( 'Your settings have been saved.' ) );
 
-		// Set currency options.
-		settings.setThousandSeparator( ',' );
-		settings.setDecimalSeparator( '.' );
-		settings.setNumberOfDecimals( '2' );
+		assert.eventually.ok( settings.hasSubTab( 'Fancy rate rates' ) );
 
+		settings.removeAdditionalTaxClass( 'Fancy rate' );
 		settings.saveChanges();
-		assert.eventually.ok( settings.hasNotice( 'Your settings have been saved.' ) );*/
+
+		assert.eventually.ifError( settings.hasSubTab( 'Fancy rate rates' ) );
 	} );
 
 	test.after( 'quit browser', () => {

--- a/test/wp-admin/wp-admin-wc-settings-tax.js
+++ b/test/wp-admin/wp-admin-wc-settings-tax.js
@@ -1,0 +1,142 @@
+/**
+ * External dependencies
+ */
+import config from 'config';
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import test from 'selenium-webdriver/testing';
+import { WebDriverManager, WebDriverHelper as helper } from 'wp-e2e-webdriver';
+import { WPLogin } from 'wp-e2e-page-objects';
+
+/**
+ * Internal dependencies
+ */
+import { WPAdminWCSettingsTax } from '../../src/index';
+
+chai.use( chaiAsPromised );
+const assert = chai.assert;
+
+let manager;
+let driver;
+
+test.describe( 'WooCommerce Tax Settings', function() {
+	test.before( 'open browser', function() {
+		this.timeout( config.get( 'startBrowserTimeoutMs' ) );
+
+		manager = new WebDriverManager( 'chrome', { baseUrl: config.get( 'url' ) } );
+		driver = manager.getDriver();
+
+		helper.clearCookiesAndDeleteLocalStorage( driver );
+	} );
+
+	this.timeout( config.get( 'mochaTimeoutMs' ) );
+
+	test.before( 'login', () => {
+		const wpLogin = new WPLogin( driver, { url: manager.getPageUrl( '/wp-login.php' ) } );
+		wpLogin.login( config.get( 'users.admin.username' ), config.get( 'users.admin.password' ) );
+	} );
+
+	test.it( 'can do something', () => {
+		const settingsArgs = { url: manager.getPageUrl( '/wp-admin/admin.php?page=wc-settings&tab=tax' ) };
+		const settings = new WPAdminWCSettingsTax( driver, settingsArgs );
+
+		assert.eventually.ok( settings.hasActiveTab( 'Tax' ) );
+
+		settings.selectPricesEnteredWithTax();
+		driver.sleep( 1000 );
+
+		settings.selectPricesEnteredWithNoTax();
+		driver.sleep( 1000 );
+
+		settings.checkRounding();
+		driver.sleep( 1000 );
+
+		settings.setPriceDisplaySuffix( 'inc. Vat' );
+		driver.sleep( 1000 );
+
+		settings.uncheckRounding();
+		driver.sleep( 1000 );
+
+		settings.selectCalculateTaxBasedOn( 'Customer shipping address' );
+		driver.sleep( 1000 );
+
+		settings.selectCalculateTaxBasedOn( 'Customer billing address' );
+		driver.sleep( 1000 );
+
+		settings.selectCalculateTaxBasedOn( 'Shop base address' );
+		driver.sleep( 1000 );
+
+		settings.selectDisplayPricesInTheShop( 'Including tax' );
+		driver.sleep( 1000 );
+
+		settings.selectDisplayTaxTotals( 'As a single total' );
+		driver.sleep( 1000 );
+
+		settings.setPriceDisplaySuffix( 'billz' );
+		driver.sleep( 1000 );
+
+		settings.selectDisplayPricesDuringCartAndCheckout( 'Excluding tax' );
+		driver.sleep( 1000 );
+
+		settings.selectDisplayPricesInTheShop( 'Excluding tax' );
+		driver.sleep( 1000 );
+
+		settings.selectDisplayTaxTotals( 'Itemized' );
+		driver.sleep( 1000 );
+
+		settings.selectDisplayPricesDuringCartAndCheckout( 'Including tax' );
+		driver.sleep( 1000 );
+
+		settings.addAdditionalTaxClass( 'test class' );
+		driver.sleep( 1000 );
+
+		settings.removeAdditionalTaxClass( 'Zero rate' );
+		driver.sleep( 1000 );
+
+		settings.addAdditionalTaxClass( 'another one' );
+		driver.sleep( 1000 );
+
+		settings.addAdditionalTaxClass( 'lets start over' );
+		driver.sleep( 1000 );
+
+		settings.removeAdditionalTaxClass( 'lets start over' );
+		driver.sleep( 1000 );
+
+		settings.removeAdditionalTaxClass( 'test class' );
+		driver.sleep( 1000 );
+
+
+/*
+		// Set selling location to all countries first, so we can choose california
+		// as base location.
+		settings.selectSellingLocation( 'Sell to all countries' );
+		settings.saveChanges();
+		assert.eventually.ok( settings.hasNotice( 'Your settings have been saved.' ) );
+
+		// Set base location with state CA.
+		settings.selectBaseLocation( 'california', 'United States (US) — California' );
+		settings.saveChanges();
+		assert.eventually.ok( settings.hasNotice( 'Your settings have been saved.' ) );
+
+		// Set selling location to specific countries first, so we can choose
+		// U.S as base location (without state). This will makes specific
+		// countries option appears.
+		settings.selectSellingLocation( 'Sell to specific countries' );
+		settings.removeChoiceInSellToSpecificCountries( 'United States (US)' );
+		settings.setSellToSpecificCountries( 'united states', 'United States (US)' );
+		settings.saveChanges();
+		assert.eventually.ok( settings.hasNotice( 'Your settings have been saved.' ) );
+
+		// Set currency options.
+		settings.setThousandSeparator( ',' );
+		settings.setDecimalSeparator( '.' );
+		settings.setNumberOfDecimals( '2' );
+
+		settings.saveChanges();
+		assert.eventually.ok( settings.hasNotice( 'Your settings have been saved.' ) );*/
+	} );
+
+	test.after( 'quit browser', () => {
+		manager.quitBrowser();
+	} );
+} );

--- a/test/wp-admin/wp-admin-wc-settings-tax.js
+++ b/test/wp-admin/wp-admin-wc-settings-tax.js
@@ -11,7 +11,7 @@ import { WPLogin } from 'wp-e2e-page-objects';
 /**
  * Internal dependencies
  */
-import { WPAdminWCSettingsTax } from '../../src/index';
+import { WPAdminWCSettingsTax , WPAdminWCSettingsTaxRates } from '../../src/index';
 
 chai.use( chaiAsPromised );
 const assert = chai.assert;
@@ -70,6 +70,37 @@ test.describe( 'WooCommerce Tax Settings', function() {
 		settings.saveChanges();
 
 		assert.eventually.ifError( settings.hasSubTab( 'Fancy rate rates' ) );
+	} );
+
+	test.it( 'can do something', () => {
+		const settingsArgs = { url: manager.getPageUrl( '/wp-admin/admin.php?page=wc-settings&tab=tax&section=standard' ) };
+		const settings = new WPAdminWCSettingsTaxRates( driver, settingsArgs );
+
+		settings.insertRow();
+		settings.insertRow();
+
+		settings.setCountryCode( 1, 'us' );
+		settings.setCountryCode( 2, 'ar' );
+		settings.setStateCode( 2, 'ca' );
+		settings.setStateCode( 1, 'or' );
+		settings.setCity( 2, 'Portland' );
+		settings.setCity( 1, 'Somewhere' );
+		settings.setRate( 1, '12' );
+		settings.setRate( 2, '15' );
+		settings.setTaxName( 1, 'First' );
+		settings.setTaxName( 2, 'Cool tax' );
+		settings.setPriority( 1, '2' );
+		settings.setPriority( 2, '3' );
+		settings.checkCompound( 1 );
+		settings.checkCompound( 2 );
+		settings.uncheckCompound( 1 );
+		settings.uncheckCompound( 2 );
+		settings.checkShipping( 3 );
+		settings.uncheckShipping( 3 );
+		driver.sleep( 4000 );
+
+		settings.removeRow( 2 );
+		driver.sleep( 10000 );
 	} );
 
 	test.after( 'quit browser', () => {


### PR DESCRIPTION
Closes #10.

I've added WPAdminWCSettingsTax and WPAdminWCSettingsTaxRates objects and tests for the admin tax settings page. 