### PR TITLE
Products general settings component modification and e2e test

### DIFF
--- a/src/pages/wp-admin/wp-admin-wc-settings-products-general.js
+++ b/src/pages/wp-admin/wp-admin-wc-settings-products-general.js
@@ -14,12 +14,16 @@ import { WebDriverHelper as helper } from 'wp-e2e-webdriver';
 import * as wcHelper from '../../helper';
 import WPAdminWCSettings from './wp-admin-wc-settings';
 
-const WEIGHT_UNIT_SELECTOR = By.css( '#s2id_woocommerce_weight_unit .select2-choice b' );
-const DIMENSIONS_UNIT_SELECTOR = By.css( '#s2id_woocommerce_dimension_unit .select2-choice b' );
-const ENABLE_REVIEW_RATING_SELECTOR = By.css( '#woocommerce_enable_review_rating' );
-const REVIEW_RATING_REQUIRED_SELECTOR = By.css( '#woocommerce_review_rating_required' );
+const SHOP_PAGE_SELECTOR = wcHelper.getSelect2ToggleSelectorByName( 'woocommerce_shop_page_id' );
+const REDIRECT_TO_THE_CART_PAGE_AFTER_SUCCESSFUL_ADDITION_SELECTOR = By.css( '#woocommerce_cart_redirect_after_add' );
+const ENABLE_AJAX_ADD_TO_CART_BUTTONS_ON_ARCHIVES_SELECTOR = By.css( '#woocommerce_enable_ajax_add_to_cart' );
+const WEIGHT_UNIT_SELECTOR = wcHelper.getSelect2ToggleSelectorByName( 'woocommerce_weight_unit' );
+const DIMENSIONS_UNIT_SELECTOR = wcHelper.getSelect2ToggleSelectorByName( 'woocommerce_dimension_unit' );
+const ENABLE_PRODUCT_REVIEWS_SELECTOR = By.css( '#woocommerce_enable_reviews' );
 const REVIEW_RATING_VERIFICATION_LABEL_SELECTOR = By.css( '#woocommerce_review_rating_verification_label' );
 const REVIEW_RATING_VERIFICATION_REQUIRED_SELECTOR = By.css( '#woocommerce_review_rating_verification_required' );
+const ENABLE_REVIEW_RATING_SELECTOR = By.css( '#woocommerce_enable_review_rating' );
+const REVIEW_RATING_REQUIRED_SELECTOR = By.css( '#woocommerce_review_rating_required' );
 
 const defaultArgs = {
 	url: '',
@@ -39,6 +43,56 @@ export default class WPAdminWCSettingsProductsGeneral extends WPAdminWCSettings 
 	constructor( driver, args = {} ) {
 		args = Object.assign( defaultArgs, args );
 		super( driver, args );
+	}
+
+	/**
+	 * Select the shop page.
+	 *
+	 * @param  {string}    option - Shop page text.
+	 * @return {Promise}   Promise that evaluates to `true` if weight unit selected successfully, `false` otherwise.
+	 */
+	selectShopPage( option ) {
+		return wcHelper.select2Option( this.driver, SHOP_PAGE_SELECTOR, option );
+	}
+
+	/**
+	 * Check the "Redirect to the cart page after successful addition" checkbox.
+	 *
+	 * @return {Promise}   Promise that evaluates to `true` if box is/gets checked successfully, `false` otherwise.
+	 */
+	checkRedirectToTheCartAfterSuccessfulAddition() {
+		helper.unsetCheckbox( this.driver, REDIRECT_TO_THE_CART_PAGE_AFTER_SUCCESSFUL_ADDITION_SELECTOR );
+		return helper.setCheckbox( this.driver, REDIRECT_TO_THE_CART_PAGE_AFTER_SUCCESSFUL_ADDITION_SELECTOR );
+	}
+
+	/**
+	 * Uncheck the "Redirect to the cart page after successful addition" checkbox.
+	 *
+	 * @return {Promise}   Promise that evaluates to `true` if box is/gets unchecked successfully, `false` otherwise.
+	 */
+	uncheckRedirectToTheCartAfterSuccessfulAddition() {
+		helper.setCheckbox( this.driver, REDIRECT_TO_THE_CART_PAGE_AFTER_SUCCESSFUL_ADDITION_SELECTOR );
+		return helper.unsetCheckbox( this.driver, REDIRECT_TO_THE_CART_PAGE_AFTER_SUCCESSFUL_ADDITION_SELECTOR );
+	}
+
+	/**
+	 * Check the "Enable AJAX add to cart buttons on archives" checkbox.
+	 *
+	 * @return {Promise}   Promise that evaluates to `true` if box is/gets checked successfully, `false` otherwise.
+	 */
+	checkEnableAjaxAddToCartButtonsOnArchives() {
+		helper.unsetCheckbox( this.driver, ENABLE_AJAX_ADD_TO_CART_BUTTONS_ON_ARCHIVES_SELECTOR );
+		return helper.setCheckbox( this.driver, ENABLE_AJAX_ADD_TO_CART_BUTTONS_ON_ARCHIVES_SELECTOR );
+	}
+
+	/**
+	 * Uncheck the "Enable AJAX add to cart buttons on archives" checkbox.
+	 *
+	 * @return {Promise}   Promise that evaluates to `true` if box is/gets unchecked successfully, `false` otherwise.
+	 */
+	uncheckEnableAjaxAddToCartButtonsOnArchives() {
+		helper.setCheckbox( this.driver, ENABLE_AJAX_ADD_TO_CART_BUTTONS_ON_ARCHIVES_SELECTOR );
+		return helper.unsetCheckbox( this.driver, ENABLE_AJAX_ADD_TO_CART_BUTTONS_ON_ARCHIVES_SELECTOR );
 	}
 
 	/**
@@ -62,43 +116,23 @@ export default class WPAdminWCSettingsProductsGeneral extends WPAdminWCSettings 
 	}
 
 	/**
-	* Check the "Enable ratings on reviews" checkbox.
-	*
- 	* @return {Promise}   Promise that evaluates to `true` if box is/gets checked successfully, `false` otherwise.
-	*/
-	checkEnableRatingsOnReviews() {
-		helper.unsetCheckbox( this.driver, ENABLE_REVIEW_RATING_SELECTOR );
-		return helper.setCheckbox( this.driver, ENABLE_REVIEW_RATING_SELECTOR );
+	 * Check the "Enable product reviews" checkbox.
+	 *
+	 * @return {Promise}   Promise that evaluates to `true` if box is/gets checked successfully, `false` otherwise.
+	 */
+	checkEnableProductReviews() {
+		helper.unsetCheckbox( this.driver, ENABLE_PRODUCT_REVIEWS_SELECTOR );
+		return helper.setCheckbox( this.driver, ENABLE_PRODUCT_REVIEWS_SELECTOR );
 	}
 
 	/**
-	* Uncheck the "Enable ratings on reviews" checkbox.
-	*
- 	* @return {Promise}   Promise that evaluates to `true` if box is/gets unchecked successfully, `false` otherwise.
-	*/
-	uncheckEnableRatingsOnReviews() {
-		helper.setCheckbox( this.driver, ENABLE_REVIEW_RATING_SELECTOR );
-		return helper.unsetCheckbox( this.driver, ENABLE_REVIEW_RATING_SELECTOR );
-	}
-
-	/**
-	* Check the "Ratings are required to leave a review" checkbox.
-	*
- 	* @return {Promise}   Promise that evaluates to `true` if box is/gets checked successfully, `false` otherwise.
-	*/
-	checkRatingsAreRequiredToLeaveReview() {
-		helper.unsetCheckbox( this.driver, REVIEW_RATING_REQUIRED_SELECTOR );
-		return helper.setCheckbox( this.driver, REVIEW_RATING_REQUIRED_SELECTOR );
-	}
-
-	/**
-	* Uncheck the "Ratings are required to leave a review" checkbox.
-	*
- 	* @return {Promise}   Promise that evaluates to `true` if box is/gets unchecked successfully, `false` otherwise.
-	*/
-	uncheckRatingsAreRequiredToLeaveReview() {
-		helper.setCheckbox( this.driver, REVIEW_RATING_REQUIRED_SELECTOR );
-		return helper.unsetCheckbox( this.driver, REVIEW_RATING_REQUIRED_SELECTOR );
+	 * Uncheck the "Enable product reviews" checkbox.
+	 *
+	 * @return {Promise}   Promise that evaluates to `true` if box is/gets unchecked successfully, `false` otherwise.
+	 */
+	uncheckEnableProductReviews() {
+		helper.setCheckbox( this.driver, ENABLE_PRODUCT_REVIEWS_SELECTOR );
+		return helper.unsetCheckbox( this.driver, ENABLE_PRODUCT_REVIEWS_SELECTOR );
 	}
 
 	/**
@@ -122,7 +156,7 @@ export default class WPAdminWCSettingsProductsGeneral extends WPAdminWCSettings 
 	}
 
 	/**
-	* Check the "Only allow reviews from 'verified owners'" checkbox.
+	* Check the "Reviews can only be left by 'verified owners'" checkbox.
 	*
  	* @return {Promise}   Promise that evaluates to `true` if box is/gets checked successfully, `false` otherwise.
 	*/
@@ -132,12 +166,52 @@ export default class WPAdminWCSettingsProductsGeneral extends WPAdminWCSettings 
 	}
 
 	/**
-	* Uncheck the "Only allow reviews from 'verified owners'" checkbox.
+	* Uncheck the "Reviews can only be left by 'verified owners'" checkbox.
 	*
  	* @return {Promise}   Promise that evaluates to `true` if box is/gets unchecked successfully, `false` otherwise.
 	*/
 	uncheckOnlyAllowReviewsFromVerifiedOwners() {
 		helper.setCheckbox( this.driver, REVIEW_RATING_VERIFICATION_REQUIRED_SELECTOR );
 		return helper.unsetCheckbox( this.driver, REVIEW_RATING_VERIFICATION_REQUIRED_SELECTOR );
+	}
+
+	/**
+	 * Check the "Enable star rating on reviews" checkbox.
+	 *
+	 * @return {Promise}   Promise that evaluates to `true` if box is/gets checked successfully, `false` otherwise.
+	 */
+	checkEnableRatingsOnReviews() {
+		helper.unsetCheckbox( this.driver, ENABLE_REVIEW_RATING_SELECTOR );
+		return helper.setCheckbox( this.driver, ENABLE_REVIEW_RATING_SELECTOR );
+	}
+
+	/**
+	 * Uncheck the "Enable star rating on reviews" checkbox.
+	 *
+	 * @return {Promise}   Promise that evaluates to `true` if box is/gets unchecked successfully, `false` otherwise.
+	 */
+	uncheckEnableRatingsOnReviews() {
+		helper.setCheckbox( this.driver, ENABLE_REVIEW_RATING_SELECTOR );
+		return helper.unsetCheckbox( this.driver, ENABLE_REVIEW_RATING_SELECTOR );
+	}
+
+	/**
+	 * Check the "Star ratings should be required, not optional" checkbox.
+	 *
+	 * @return {Promise}   Promise that evaluates to `true` if box is/gets checked successfully, `false` otherwise.
+	 */
+	checkRatingsAreRequiredToLeaveReview() {
+		helper.unsetCheckbox( this.driver, REVIEW_RATING_REQUIRED_SELECTOR );
+		return helper.setCheckbox( this.driver, REVIEW_RATING_REQUIRED_SELECTOR );
+	}
+
+	/**
+	 * Uncheck the "Star ratings should be required, not optional" checkbox.
+	 *
+	 * @return {Promise}   Promise that evaluates to `true` if box is/gets unchecked successfully, `false` otherwise.
+	 */
+	uncheckRatingsAreRequiredToLeaveReview() {
+		helper.setCheckbox( this.driver, REVIEW_RATING_REQUIRED_SELECTOR );
+		return helper.unsetCheckbox( this.driver, REVIEW_RATING_REQUIRED_SELECTOR );
 	}
 }

--- a/test/wp-admin/wp-admin-wc-settings-products-general.js
+++ b/test/wp-admin/wp-admin-wc-settings-products-general.js
@@ -1,0 +1,108 @@
+/**
+ * External dependencies
+ */
+import config from 'config';
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import test from 'selenium-webdriver/testing';
+import { WebDriverManager, WebDriverHelper as helper } from 'wp-e2e-webdriver';
+import { WPLogin } from 'wp-e2e-page-objects';
+
+/**
+ * Internal dependencies
+ */
+import { WPAdminWCSettingsProductsGeneral } from '../../src/index';
+
+chai.use( chaiAsPromised );
+const assert = chai.assert;
+
+let manager;
+let driver;
+
+test.describe( 'WooCommerce Products > General Settings', function() {
+	// open browser
+	test.before( function() {
+		this.timeout( config.get( 'startBrowserTimeoutMs' ) );
+
+		manager = new WebDriverManager( 'chrome', { baseUrl: config.get( 'url' ) } );
+		driver = manager.getDriver();
+
+		helper.clearCookiesAndDeleteLocalStorage( driver );
+	} );
+
+	this.timeout( config.get( 'mochaTimeoutMs' ) );
+
+	// login
+	test.before( () => {
+		const wpLogin = new WPLogin( driver, { url: manager.getPageUrl( '/wp-login.php' ) } );
+		wpLogin.login( config.get( 'users.admin.username' ), config.get( 'users.admin.password' ) );
+	} );
+
+	test.it( 'can update settings', () => {
+		const settingsArgs = { url: manager.getPageUrl( '/wp-admin/admin.php?page=wc-settings&tab=products&section' ) };
+		const settings = new WPAdminWCSettingsProductsGeneral( driver, settingsArgs );
+
+		assert.eventually.ok( settings.hasActiveTab( 'Products' ) );
+		assert.eventually.ok( settings.hasActiveSubTab( 'General' ) );
+
+		// Set shop page to Shop
+		settings.selectShopPage( 'Shop' );
+
+		// Select add to cart behaviour options
+		settings.checkRedirectToTheCartAfterSuccessfulAddition();
+		settings.checkEnableAjaxAddToCartButtonsOnArchives();
+
+		// Set measurements (kg, m)
+		settings.selectWeightUnit( 'kg' );
+		settings.selectDimensionsUnit( 'm' );
+
+		// Select the checkbox to enable reviews so that the corresponding fields appear.
+		// Set the rest of the settings in the Reviews section
+		settings.checkEnableProductReviews();
+		settings.checkShowVerifiedOwnerLabel();
+		settings.checkOnlyAllowReviewsFromVerifiedOwners();
+		settings.checkEnableRatingsOnReviews();
+		settings.checkRatingsAreRequiredToLeaveReview();
+		settings.saveChanges();
+		assert.eventually.ok( settings.hasNotice( 'Your settings have been saved.' ) );
+
+		// Deselect add to cart behaviour options
+		settings.uncheckRedirectToTheCartAfterSuccessfulAddition();
+		settings.uncheckEnableAjaxAddToCartButtonsOnArchives();
+		// Set measurements (lbs, in)
+		settings.selectWeightUnit( 'lbs' );
+		settings.selectDimensionsUnit( 'in' );
+		// Select the checkbox to disable reviews so that the corresponding fields disappear.
+		settings.uncheckEnableProductReviews();
+		settings.saveChanges();
+		assert.eventually.ok( settings.hasNotice( 'Your settings have been saved.' ) );
+
+		// Select add to cart behaviour options
+		settings.checkRedirectToTheCartAfterSuccessfulAddition();
+		settings.checkEnableAjaxAddToCartButtonsOnArchives();
+		// Set measurements (oz, yd)
+		settings.selectWeightUnit( 'oz' );
+		settings.selectDimensionsUnit( 'yd' );
+		// Select the checkbox to enable reviews so that the corresponding fields appear.
+		// Set the rest of the settings in the Reviews section
+		settings.checkEnableProductReviews();
+		settings.checkShowVerifiedOwnerLabel();
+		settings.checkOnlyAllowReviewsFromVerifiedOwners();
+		settings.checkEnableRatingsOnReviews();
+		settings.checkRatingsAreRequiredToLeaveReview();
+		settings.saveChanges();
+		assert.eventually.ok( settings.hasNotice( 'Your settings have been saved.' ) );
+	} );
+
+	// take screenshot
+	test.afterEach( function() {
+		if ( this.currentTest.state === 'failed' ) {
+			helper.takeScreenshot( manager, this.currentTest );
+		}
+	} );
+
+	// quit browser
+	test.after( () => {
+		manager.quitBrowser();
+	} );
+} );


### PR DESCRIPTION
Scope of this PR:

1) Added missing fields to the `wc-settings-products-general` component:
   a) Shop page;
   b) Redirect to the cart page after successful addition;
   c) Enable AJAX add to cart buttons on archives;
   d) Enable product reviews. 

![](https://cloudup.com/cD9ZRc1gJ7w+)
Image Link: https://cloudup.com/cD9ZRc1gJ7w

2) Changed the order in which the fields are listed in the `wc-settings-products-general` component.  This is to match the order in which the fields are being displayed on the page at the front-end for better code readability of the component. 

3) Added e2e test for the `wc-settings-products-general` page. Video showing the test and its passing is below:

http://g.recordit.co/vrZCyUsVGb.gif
