### PR TITLE
Documentation updates related to setting up local test environment

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -22,7 +22,7 @@ the what you expected to see and what happened instead.
 Before running the test, make sure to:
 
 * Set a test site with latest WP, WC, and Storefront.
-* Import the [dummy-data products](https://github.com/woocommerce/woocommerce/blob/master/dummy-data/dummy-products.csv)
+* Import the [sample products](https://github.com/woocommerce/woocommerce/blob/master/sample-data/sample_products.csv)
   from WC using WC products importer.
 * Create a `test/config/local-{env}.json`
 * Set your site's configuration there. For example if active environment is

--- a/test/README.md
+++ b/test/README.md
@@ -14,7 +14,9 @@ npm run test
 ## Test configs
 
 Test config files can be found in `test/config`. To override specific config
-based on active environment, create a `local-{env}.json` file. It's gitignored.
+based on active environment, create a `local-{env}.json` file. It's gitignored. 
+More detailed instructions could be found 
+[here](https://github.com/woocommerce/wc-e2e-page-objects/blob/master/.github/CONTRIBUTING.md#tests). 
 
 ## Running specific test file
 


### PR DESCRIPTION
Scope of this PR:

1) Added link to more detailed instructions on how to set up the local test environment on `wc-e2e-page-objects/test/` page;

2) Fixed the link to the sample data that needs to be donwloaded to set up local test environment in `wc-e2e-page-objects/.github/CONTRIBUTING.md`. 