### PR TITLE
Add products inventory settings object and its e2e test

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -27,6 +27,7 @@ import WPAdminWCSettingsProductsDownloadable from './pages/wp-admin/wp-admin-wc-
 import StoreOwnerFlow from './flows/store-owner-flow';
 import GuestCustomerFlow from './flows/guest-customer-flow';
 import CustomerFlow from './flows/customer-flow';
+import WPAdminWCSettingsProductsInventory from "./pages/wp-admin/wp-admin-wc-settings-products-inventory";
 
 export {
 	PageMap,
@@ -55,4 +56,5 @@ export {
 	StoreOwnerFlow,
 	GuestCustomerFlow,
 	CustomerFlow,
+	WPAdminWCSettingsProductsInventory,
 };

--- a/src/pages/wp-admin/wp-admin-wc-settings-products-inventory.js
+++ b/src/pages/wp-admin/wp-admin-wc-settings-products-inventory.js
@@ -1,0 +1,176 @@
+/**
+ * @module WPAdminWCSettingsProductsInventory
+ */
+
+/**
+ * External dependencies
+ */
+import { By } from 'selenium-webdriver';
+import { WebDriverHelper as helper } from 'wp-e2e-webdriver';
+
+/**
+ * Internal Dependencies
+ */
+import * as wcHelper from '../../helper';
+import WPAdminWCSettings from './wp-admin-wc-settings';
+
+const STOCK_MANAGEMENT_SELECTOR = By.css( '#woocommerce_manage_stock' );
+const HOLD_STOCK_MINUTES_SELECTOR = By.css( '#woocommerce_hold_stock_minutes' );
+const LOW_STOCK_NOTIFICATIONS_SELECTOR = By.css( '#woocommerce_notify_low_stock' );
+const OUT_OF_STOCK_NOTIFICATIONS_SELECTOR = By.css( '#woocommerce_notify_no_stock' );
+const NOTIFICATION_RECIPIENTS_SELECTOR = By.css( '#woocommerce_stock_email_recipient' );
+const LOW_STOCK_THRESHOLD_SELECTOR = By.css( '#woocommerce_notify_low_stock_amount' );
+const OUT_OF_STOCK_THRESHOLD_SELECTOR = By.css( '#woocommerce_notify_no_stock_amount' );
+const OUT_OF_STOCK_VISIBILITY_SELECTOR = By.css( '#woocommerce_hide_out_of_stock_items' );
+const STOCK_DISPLAY_FORMAT_SELECTOR = wcHelper.getSelect2ToggleSelectorByName( 'woocommerce_stock_format' );
+
+const defaultArgs = {
+	url: '',
+	visit: true,
+};
+
+/**
+ * The Products: Inventory settings screen
+ *
+ * @extends WPAdminWCSettings
+ */
+export default class WPAdminWCSettingsProductsInventory extends WPAdminWCSettings {
+	/**
+	 * @param {WebDriver} driver   - Instance of WebDriver.
+	 * @param {object}    args     - Configuration arguments.
+	 */
+	constructor(driver, args = {}) {
+		args = Object.assign(defaultArgs, args);
+		super(driver, args);
+	}
+
+	/**
+	 * Check the "Enable stock management" checkbox.
+	 *
+	 * @return {Promise}   Promise that evaluates to `true` if box is/gets checked successfully, `false` otherwise.
+	 */
+	checkEnableStockManagement() {
+		helper.unsetCheckbox( this.driver, STOCK_MANAGEMENT_SELECTOR );
+		return helper.setCheckbox( this.driver, STOCK_MANAGEMENT_SELECTOR );
+	}
+
+	/**
+	 * Uncheck the "Enable stock management" checkbox.
+	 *
+	 * @return {Promise}   Promise that evaluates to `true` if box is/gets unchecked successfully, `false` otherwise.
+	 */
+	uncheckEnableStockManagement() {
+		helper.setCheckbox( this.driver, STOCK_MANAGEMENT_SELECTOR );
+		return helper.unsetCheckbox( this.driver, STOCK_MANAGEMENT_SELECTOR );
+	}
+
+	/**
+	 * Set the hold stock (minutes) input.
+	 *
+	 * @param  {number}    num          - Number of minutes.
+	 * @return {Promise}   Promise that evaluates to `true` if number of minutes set successfully, `false` otherwise.
+	 */
+	setHoldStockMinutes( num ) {
+		return helper.setWhenSettable( this.driver, HOLD_STOCK_MINUTES_SELECTOR, num );
+	}
+
+	/**
+	 * Check the "Enable low stock notifications" checkbox.
+	 *
+	 * @return {Promise}   Promise that evaluates to `true` if box is/gets checked successfully, `false` otherwise.
+	 */
+	checkEnableLowStockNotifications() {
+		helper.unsetCheckbox( this.driver, LOW_STOCK_NOTIFICATIONS_SELECTOR );
+		return helper.setCheckbox( this.driver, LOW_STOCK_NOTIFICATIONS_SELECTOR );
+	}
+
+	/**
+	 * Uncheck the "Enable low stock notifications" checkbox.
+	 *
+	 * @return {Promise}   Promise that evaluates to `true` if box is/gets unchecked successfully, `false` otherwise.
+	 */
+	uncheckEnableLowStockNotifications() {
+		helper.setCheckbox( this.driver, LOW_STOCK_NOTIFICATIONS_SELECTOR );
+		return helper.unsetCheckbox( this.driver, LOW_STOCK_NOTIFICATIONS_SELECTOR );
+	}
+
+	/**
+	 * Check the "Enable out of stock notifications" checkbox.
+	 *
+	 * @return {Promise}   Promise that evaluates to `true` if box is/gets checked successfully, `false` otherwise.
+	 */
+	checkEnableOutOfStockNotifications() {
+		helper.unsetCheckbox( this.driver, OUT_OF_STOCK_NOTIFICATIONS_SELECTOR );
+		return helper.setCheckbox( this.driver, OUT_OF_STOCK_NOTIFICATIONS_SELECTOR );
+	}
+
+	/**
+	 * Uncheck the "Enable out of stock notifications" checkbox.
+	 *
+	 * @return {Promise}   Promise that evaluates to `true` if box is/gets unchecked successfully, `false` otherwise.
+	 */
+	uncheckEnableOutOfStockNotifications() {
+		helper.setCheckbox( this.driver, OUT_OF_STOCK_NOTIFICATIONS_SELECTOR );
+		return helper.unsetCheckbox( this.driver, OUT_OF_STOCK_NOTIFICATIONS_SELECTOR );
+	}
+
+	/**
+	 * Set the notification recipient(s) input.
+	 *
+	 * @param  {string}    email    - Notification recipient(s) email.
+	 * @return {Promise}   Promise that evaluates to `true` if email set successfully, `false` otherwise.
+	 */
+	setNotificationRecipients( email ) {
+		return helper.setWhenSettable( this.driver, NOTIFICATION_RECIPIENTS_SELECTOR, email );
+	}
+
+	/**
+	 * Set the low stock threshold input.
+	 *
+	 * @param  {number}    num          - Number of items.
+	 * @return {Promise}   Promise that evaluates to `true` if number of items set successfully, `false` otherwise.
+	 */
+	setLowStockThreshold( num ) {
+		return helper.setWhenSettable( this.driver, LOW_STOCK_THRESHOLD_SELECTOR, num );
+	}
+
+	/**
+	 * Set the out of stock threshold input.
+	 *
+	 * @param  {number}    num          - Number of items.
+	 * @return {Promise}   Promise that evaluates to `true` if number of items set successfully, `false` otherwise.
+	 */
+	setOutOfStockThreshold( num ) {
+		return helper.setWhenSettable( this.driver, OUT_OF_STOCK_THRESHOLD_SELECTOR, num );
+	}
+
+	/**
+	 * Check the "Hide out of stock items from the catalog" checkbox.
+	 *
+	 * @return {Promise}   Promise that evaluates to `true` if box is/gets checked successfully, `false` otherwise.
+	 */
+	checkEnableHideOutOfStockItemsFromTheCatalog() {
+		helper.unsetCheckbox( this.driver, OUT_OF_STOCK_VISIBILITY_SELECTOR );
+		return helper.setCheckbox( this.driver, OUT_OF_STOCK_VISIBILITY_SELECTOR );
+	}
+
+	/**
+	 * Uncheck the "Hide out of stock items from the catalog" checkbox.
+	 *
+	 * @return {Promise}   Promise that evaluates to `true` if box is/gets unchecked successfully, `false` otherwise.
+	 */
+	uncheckEnableHideOutOfStockItemsFromTheCatalog() {
+		helper.setCheckbox( this.driver, OUT_OF_STOCK_VISIBILITY_SELECTOR );
+		return helper.unsetCheckbox( this.driver, OUT_OF_STOCK_VISIBILITY_SELECTOR );
+	}
+
+	/**
+	 * Select the stock display format.
+	 *
+	 * @param  {string}    option - stock display format text.
+	 * @return {Promise}   Promise that evaluates to `true` if stock display format selected successfully, `false` otherwise.
+	 */
+	selectStockDisplayFormat( option ) {
+		return wcHelper.select2Option( this.driver, STOCK_DISPLAY_FORMAT_SELECTOR, option );
+	}
+}

--- a/test/wp-admin/wp-admin-wc-settings-products-inventory.js
+++ b/test/wp-admin/wp-admin-wc-settings-products-inventory.js
@@ -1,0 +1,78 @@
+/**
+ * External dependencies
+ */
+import config from 'config';
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import test from 'selenium-webdriver/testing';
+import { WebDriverManager, WebDriverHelper as helper } from 'wp-e2e-webdriver';
+import { WPLogin } from 'wp-e2e-page-objects';
+
+/**
+ * Internal dependencies
+ */
+import { WPAdminWCSettingsProductsInventory } from '../../src/index';
+
+chai.use( chaiAsPromised );
+const assert = chai.assert;
+
+let manager;
+let driver;
+
+test.describe( 'WooCommerce Products > Inventory Products Settings', function() {
+	// open browser
+	test.before( function() {
+		this.timeout( config.get( 'startBrowserTimeoutMs' ) );
+
+		manager = new WebDriverManager( 'chrome', { baseUrl: config.get( 'url' ) } );
+		driver = manager.getDriver();
+
+		helper.clearCookiesAndDeleteLocalStorage( driver );
+	} );
+
+	this.timeout( config.get( 'mochaTimeoutMs' ) );
+
+	// login
+	test.before( () => {
+		const wpLogin = new WPLogin( driver, { url: manager.getPageUrl( '/wp-login.php' ) } );
+		wpLogin.login( config.get( 'users.admin.username' ), config.get( 'users.admin.password' ) );
+	} );
+
+	test.it( 'can update settings', () => {
+		const settingsArgs = { url: manager.getPageUrl( '/wp-admin/admin.php?page=wc-settings&tab=products&section=inventory' ) };
+		const settings = new WPAdminWCSettingsProductsInventory( driver, settingsArgs );
+
+		assert.eventually.ok( settings.hasActiveTab( 'Products' ) );
+		assert.eventually.ok( settings.hasActiveSubTab( 'Inventory' ) );
+
+		// Enable stock management flow
+		settings.checkEnableStockManagement();
+		settings.setHoldStockMinutes( '60' );
+		settings.checkEnableLowStockNotifications();
+		settings.checkEnableOutOfStockNotifications();
+		settings.setNotificationRecipients( 'woologin@woocommerce.com' );
+		settings.setLowStockThreshold( '5' );
+		settings.setOutOfStockThreshold( '0' );
+		settings.checkEnableHideOutOfStockItemsFromTheCatalog();
+		settings.saveChanges();
+		assert.eventually.ok( settings.hasNotice( 'Your settings have been saved.' ) );
+
+		// Enable stock management but disable all other checkboxes on the page flow
+		settings.uncheckEnableLowStockNotifications();
+		settings.uncheckEnableOutOfStockNotifications();
+		settings.uncheckEnableHideOutOfStockItemsFromTheCatalog();
+		settings.saveChanges();
+		assert.eventually.ok( settings.hasNotice( 'Your settings have been saved.' ) );
+
+		// Disable stock management flow
+		settings.uncheckEnableStockManagement();
+		settings.selectStockDisplayFormat( 'Never show quantity remaining in stock' );
+		settings.saveChanges();
+		assert.eventually.ok( settings.hasNotice( 'Your settings have been saved.' ) );
+	} );
+
+	// quit browser
+	test.after( () => {
+		manager.quitBrowser();
+	} );
+} );


### PR DESCRIPTION
Scope of this PR:

1) Added Products Inventory Settings object:

![](https://cloudup.com/chBrg7AY9rM+)
Image Link: https://cloudup.com/chBrg7AY9rM

2) Added e2e test for the `wc-settings-products-inventory` page. Video showing the test and its passing is below:

http://recordit.co/XGsNh14BbH

**Note:** I used `woologin@woocommerce.com` email address as `Notification recipient(s)` email. Let me know if I should use another email address. 